### PR TITLE
Added loading spinner when the initial auth is working

### DIFF
--- a/LibraryApp/src/app/screens/Login/index.js
+++ b/LibraryApp/src/app/screens/Login/index.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { isPasswordValid, isEmailValid } from '@utils/validations';
 import authActions from '@redux/auth/actions';
+import withLoading from '@components/LoadingHOC';
 
 import Login from './layout';
 import { EMAIL_ERROR, PASSWORD_ERROR } from './constants';
@@ -66,14 +67,17 @@ LoginContainer.propTypes = {
 };
 
 const mapStateToProps = store => ({
-  authError: store.auth.authError
+  authError: store.auth.authError,
+  loading: store.auth.initialAuthLoading
 });
 
 const mapDispatchToProps = dispatch => ({
   login: (email, password) => dispatch(authActions.login(email, password))
 });
 
+const LoginWithLoading = withLoading(LoginContainer);
+
 export default connect(
   mapStateToProps,
   mapDispatchToProps
-)(LoginContainer);
+)(LoginWithLoading);

--- a/LibraryApp/src/redux/auth/actions.js
+++ b/LibraryApp/src/redux/auth/actions.js
@@ -7,7 +7,9 @@ export const actions = {
   LOGIN_SUCCESS: 'LOGIN_SUCCESS',
   LOGIN_FAILURE: 'LOGIN_FAILURE',
   LOGOUT: 'LOGOUT',
-  AUTH_INIT: 'AUTH_INIT'
+  AUTH_INIT: 'AUTH_INIT',
+  AUTH_INIT_SUCCESS: 'AUTH_INIT_SUCCESS',
+  AUTH_INIT_FAILURE: 'AUTH_INIT_FAILURE'
 };
 
 const privateActionCreators = {
@@ -26,8 +28,10 @@ const privateActionCreators = {
     });
   },
   initWithStoredUser: () => async dispatch => {
+    dispatch({ type: actions.AUTH_INIT });
     const tokens = await AuthService.getCurrentUser();
     if (!tokens.authenticated) {
+      dispatch({ type: actions.AUTH_INIT_FAILURE });
       dispatch(
         NavigationActions.navigate({
           routeName: Routes.Login
@@ -35,12 +39,12 @@ const privateActionCreators = {
       );
     } else {
       await AuthService.setCurrentUser(tokens.headers);
-      dispatch({ type: actions.AUTH_INIT });
       dispatch(
         NavigationActions.navigate({
           routeName: Routes.Library
         })
       );
+      dispatch({ type: actions.AUTH_INIT_SUCCESS });
     }
   }
 };

--- a/LibraryApp/src/redux/auth/reducer.js
+++ b/LibraryApp/src/redux/auth/reducer.js
@@ -5,15 +5,25 @@ import { actions } from './actions';
 const initialState = {
   loading: false,
   logged: false,
-  authError: null
+  authError: null,
+  initialAuthLoading: false
 };
 
 const reducer = (state = immutable(initialState), action) => {
   switch (action.type) {
-    case actions.INIT_STORED_USER:
+    case actions.AUTH_INIT:
+      return state.merge({
+        initialAuthLoading: true
+      });
+    case actions.AUTH_INIT_SUCCESS:
       return state.merge({
         loading: false,
-        logged: true
+        logged: true,
+        initialAuthLoading: false
+      });
+    case actions.AUTH_INIT_FAILURE:
+      return state.merge({
+        initialAuthLoading: false
       });
     case actions.LOGIN_REQUEST:
       return state.merge({


### PR DESCRIPTION
## Summary
- Added a loading spinner when the initial auth is working

## Screenshots

### Android
![loadingSpinnerLogin-nexus6p](https://user-images.githubusercontent.com/45210177/61462760-95a78000-a949-11e9-9cd2-4d43c210c7e8.gif)
![loadingSpinnerBooklist-nexus6p](https://user-images.githubusercontent.com/45210177/61462767-993b0700-a949-11e9-9c38-153e2fe753e2.gif)

### iOS
![loadingSpinnerLogin-iphone6](https://user-images.githubusercontent.com/45210177/61462774-9dffbb00-a949-11e9-9cd7-9f358262250d.gif)
![loadingSpinnerBooklist-iphone6](https://user-images.githubusercontent.com/45210177/61462778-a1934200-a949-11e9-80ef-0f8b694fc0e1.gif)

## Trello card
https://trello.com/c/hVN98Zi0/41-n-96-persistencia-de-sesi%C3%B3n
